### PR TITLE
Post in Plan#queue wasn't passing authenticated cookies

### DIFF
--- a/lib/bamboo-client/http/json.rb
+++ b/lib/bamboo-client/http/json.rb
@@ -39,6 +39,8 @@ module Bamboo
           end
         end # Doc
 
+        attr_reader :cookies
+        
         def post(uri_or_path, data = {}, cookies = nil)
           resp = RestClient.post(uri_for(uri_or_path), data.to_json, :accept => :json, :content_type => :json, :cookies => cookies)
           Doc.from(resp) unless resp.empty?
@@ -52,7 +54,7 @@ module Bamboo
         def get_cookies(uri_or_path, params = nil)
           uri = uri_for(uri_or_path, nil)
           resp = RestClient.get(uri, :params => params)
-          resp.cookies
+          @cookies = resp.cookies
         end
 
       end # Json

--- a/lib/bamboo-client/rest.rb
+++ b/lib/bamboo-client/rest.rb
@@ -74,7 +74,7 @@ module Bamboo
         end
 
         def queue
-          @http.post File.join(SERVICE, "queue/#{key}")
+          @http.post File.join(SERVICE, "queue/#{key}"), {}, @http.cookies
         end
       end # Plan
 

--- a/spec/bamboo-client/rest_spec.rb
+++ b/spec/bamboo-client/rest_spec.rb
@@ -73,7 +73,8 @@ module Bamboo
         end
 
         it "can be queued" do
-          http.should_receive(:post).with("/rest/api/latest/queue/S2RB-REMWIN")
+          http.should_receive(:cookies)
+          http.should_receive(:post).with("/rest/api/latest/queue/S2RB-REMWIN", {}, nil)
           plan.queue
         end
       end # Plan


### PR DESCRIPTION
This is a fix for Plan#queue not using authenticated cookies. I added an accessor for the cookies that are generated at login. Before it would return a 401 when trying to POST to the Bamboo server.
