### PR TITLE
Fix bug in Queue

### DIFF
--- a/lib/bamboo-client/rest.rb
+++ b/lib/bamboo-client/rest.rb
@@ -54,7 +54,7 @@ module Bamboo
       end
 
       def queue
-        get("queue/").auto_expand Queue, @http
+        Queue.new get("queue/").data, @http
       end
 
       private

--- a/spec/bamboo-client/rest_spec.rb
+++ b/spec/bamboo-client/rest_spec.rb
@@ -49,12 +49,12 @@ module Bamboo
       end
 
       it "should be able to fetch the queue" do
-        document.should_receive(:auto_expand).with(Rest::Queue, http).and_return %w[foo bar]
+        document.should_receive(:data).and_return('some' => 'data')
 
         http.should_receive(:get).with("/rest/api/latest/queue/", nil, nil).
                                   and_return(document)
 
-        client.queue.should == %w[foo bar]
+        client.queue().should be_kind_of(Rest::Queue)
       end
 
       it "should be able to fetch results for a specific key" do


### PR DESCRIPTION
Sorry, had a little bug in there.

Queue's @data was being populated in two different ways which meant
that a call to size would fail unless queuedBuilds had been expanded.

Updated test to support.
