### PR TITLE
Rest interface bug fix

### DIFF
--- a/features/rest.feature
+++ b/features/rest.feature
@@ -5,6 +5,7 @@ Feature: Bamboo REST client
 
   Background:
     Given I am using the REST client
+    And I log in
 
   Scenario: Fetch plans
     When I fetch all the plans
@@ -27,7 +28,6 @@ Feature: Bamboo REST client
     And all results should have a state
 
   Scenario: Authenticated API
-    When I log in
     Then I should get a session ID
     When I fetch all results
     Then all results should have a state

--- a/lib/bamboo-client/rest.rb
+++ b/lib/bamboo-client/rest.rb
@@ -60,7 +60,7 @@ module Bamboo
       private
 
       def get(what, params = nil)
-        @http.get File.join(SERVICE, what), params, @cookies
+        @http.get File.join(SERVICE, what), params
       end
 
       class Plan

--- a/spec/bamboo-client/rest_spec.rb
+++ b/spec/bamboo-client/rest_spec.rb
@@ -23,7 +23,6 @@ module Bamboo
 
         http.should_receive(:get).with(
           "/rest/api/latest/plan/",
-          nil,
           nil
         ).and_return(document)
 
@@ -33,7 +32,7 @@ module Bamboo
       it "should be able to fetch projects" do
         document.should_receive(:auto_expand).with(Rest::Project, http).and_return %w[foo bar]
 
-        http.should_receive(:get).with("/rest/api/latest/project/", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/project/", nil).
                                   and_return(document)
 
         client.projects.should == %w[foo bar]
@@ -42,7 +41,7 @@ module Bamboo
       it "should be able to fetch results" do
         document.should_receive(:auto_expand).with(Rest::Result, http).and_return %w[foo bar]
 
-        http.should_receive(:get).with("/rest/api/latest/result/", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/result/", nil).
                                   and_return(document)
 
         client.results.should == %w[foo bar]
@@ -51,7 +50,7 @@ module Bamboo
       it "should be able to fetch the queue" do
         document.should_receive(:data).and_return('some' => 'data')
 
-        http.should_receive(:get).with("/rest/api/latest/queue/", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/queue/", nil).
                                   and_return(document)
 
         client.queue().should be_kind_of(Rest::Queue)
@@ -60,7 +59,7 @@ module Bamboo
       it "should be able to fetch results for a specific key" do
         document.should_receive(:auto_expand).with(Rest::Result, http).and_return %w[foo bar]
 
-        http.should_receive(:get).with("/rest/api/latest/result/SOME-KEY", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/result/SOME-KEY", nil).
                                   and_return(document)
 
         client.results_for("SOME-KEY").should == %w[foo bar]
@@ -69,7 +68,7 @@ module Bamboo
       it "should be able to fetch a plan for a specific key" do
         document.should_receive(:data).and_return('some' => 'data')
 
-        http.should_receive(:get).with("/rest/api/latest/plan/SOME-KEY", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/plan/SOME-KEY", nil).
                                   and_return(document)
 
         client.plan_for("SOME-KEY").should be_kind_of(Rest::Plan)
@@ -79,7 +78,7 @@ module Bamboo
       it "should be able to fetch a project for a specific key" do
         document.should_receive(:data).and_return('some' => 'data')
 
-        http.should_receive(:get).with("/rest/api/latest/project/SOME-KEY", nil, nil).
+        http.should_receive(:get).with("/rest/api/latest/project/SOME-KEY", nil).
                                   and_return(document)
 
         client.project_for("SOME-KEY").should be_kind_of(Rest::Project)


### PR DESCRIPTION
- Rest call to http.get now takes 2 paramameters, not 3. The Rest class cookies field is no longer needed but was left in to minimize test changes (removing it breaks spec and cucumber tests).
- Rest cucumber tests: Login in the background so the scenarios work with an https server.
